### PR TITLE
Bump profunctors upper bound

### DIFF
--- a/colors.cabal
+++ b/colors.cabal
@@ -22,4 +22,4 @@ source-repository head
 library
   exposed-modules:     Data.Color, Data.Color.Names, Data.Color.Class
   -- other-modules:       
-  build-depends:       base ==4.*, profunctors ==3.*
+  build-depends:       base ==4.*, profunctors >= 3 && < 5


### PR DESCRIPTION
Bump profunctors upper bound--it builds fine with 4.0.1
