### PR TITLE
Remove upper limit for profunctors, bump version

### DIFF
--- a/colors.cabal
+++ b/colors.cabal
@@ -1,5 +1,5 @@
 name:                colors
-version:             0.3.0.2
+version:             0.3.0.3
 synopsis:            A type for colors
 -- description:
 homepage:            https://github.com/fumieval/colors
@@ -19,4 +19,4 @@ source-repository head
 library
   exposed-modules:     Data.Color, Data.Color.Names, Data.Color.Class
   -- other-modules:
-  build-depends:       base ==4.*, profunctors >= 3 && < 5, linear, lens >= 4.0 && <5
+  build-depends:       base ==4.*, profunctors >= 3, linear, lens >= 4.0 && <5


### PR DESCRIPTION
Current config cause backjump error when using free-game ()
With profunctors-5.1.1(last) module normaly installed and worked.
Please, upload new version, or update hackage info for 0.3.0.2
